### PR TITLE
Fix import of types from *.d.ts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,14 @@
     "import"
   ],
 
+  "settings": {
+    "import/resolver": {
+      "typescript": {
+        "alwaysTryTypes": true
+      }
+    }
+  },
+
   "rules": {
     // ES spec ESLint rules
     "strict": ["error", "global"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -17,14 +17,6 @@
     "import"
   ],
 
-  "settings": {
-    "import/resolver": {
-      "typescript": {
-        "alwaysTryTypes": true
-      }
-    }
-  },
-
   "rules": {
     // ES spec ESLint rules
     "strict": ["error", "global"],
@@ -637,6 +629,14 @@
         "project": "tsconfig.json",
         "tsconfigRootDir": ".",
         "sourceType": "module"
+      },
+
+      "settings": {
+        "import/resolver": {
+          "typescript": {
+            "alwaysTryTypes": true
+          }
+        }
       },
 
       "rules": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -546,7 +546,7 @@
     "import/no-cycle": "warn",
 
     "import/no-absolute-path": "error",
-    "import/no-relative-parent-imports": "error",
+    "import/no-relative-parent-imports": "off",
     "import/no-extraneous-dependencies": "off",
     "import/no-useless-path-segments": "error",
     "import/no-self-import": "error",
@@ -626,16 +626,6 @@
       "rules": {
         "import/no-nodejs-modules": "off",
         "import/order": "off"
-      }
-    },
-
-    {
-      "files": [
-        "./src/entries/**/*.js"
-      ],
-
-      "rules": {
-        "import/no-relative-parent-imports": "off"
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@v4fire/typescript-check": "^1.1.0",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.4.0",
+    "eslint-import-resolver-typescript": "^2.0.0",
     "eslint-plugin-enchanted-curly": "1.0.1",
     "eslint-plugin-import": "2.22.0",
     "prettier": "^2.0.5",


### PR DESCRIPTION
**Problem**: Import of types from `somefile.d.ts` doesn't work

**Related issue**: https://github.com/benmosher/eslint-plugin-import/issues/1341

**Solution**: installing [eslint-import-resolver-typescript](https://github.com/alexgorbatchev/eslint-import-resolver-typescript)

But with `eslint-import-resolver-typescript` the rule `import/no-relative-parent-imports` triggers on almost every import because is was used in wrong way. [Proof](https://github.com/benmosher/eslint-plugin-import/issues/1392):

> the point of the rule is about resolved parent imports, not aliased ones

> the path you type in your code shouldn't matter - only what it resolves to should matter

So the rule `import/no-relative-parent-imports` has to be disabled. It just didn't work before because it couldn't resolve imports of *.ts.