### PR TITLE
Disable `no-duplicate-imports` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -331,7 +331,7 @@
 
     // Imports
 
-    "no-duplicate-imports": "error",
+    "no-duplicate-imports": "off",
     "no-useless-rename": "off",
 
     // Functions


### PR DESCRIPTION
Problems:
* The rule is duplicated by `import/no-duplicates`
* The rule disallows using `import` and `import type` with the same module

Proofs:
* https://github.com/airbnb/javascript/issues/1195
* https://gitlab.sumatosoft.com/employees/javascript-style-guide/commit/4a005b1322e8baecec4b4951ce8974af641922f9
* https://github.com/standard/standard/issues/599